### PR TITLE
Add Monitoring Tests

### DIFF
--- a/.github/workflows/lint-and-test-model-training.yml
+++ b/.github/workflows/lint-and-test-model-training.yml
@@ -28,3 +28,10 @@ jobs:
       run: |
         flake8 sentiment_model_trainer/ tests/ --max-line-length=100 --ignore=E501,E203,E266,W503,F403,F401 --exclude=.git,__pycache__,build,dist
 
+    - name: Run all tests with coverage
+      run: |
+        pip install coverage
+        coverage run -m pytest
+        coverage report
+        coverage xml
+      

--- a/.github/workflows/lint-and-test-model-training.yml
+++ b/.github/workflows/lint-and-test-model-training.yml
@@ -28,10 +28,10 @@ jobs:
       run: |
         flake8 sentiment_model_trainer/ tests/ --max-line-length=100 --ignore=E501,E203,E266,W503,F403,F401 --exclude=.git,__pycache__,build,dist
 
-    - name: Run all tests with coverage
-      run: |
-        pip install coverage
-        coverage run -m pytest
-        coverage report
-        coverage xml
+    # - name: Run all tests with coverage
+    #   run: |
+    #     pip install coverage
+    #     coverage run -m pytest
+    #     coverage report
+    #     coverage xml
       

--- a/.github/workflows/lint-and-test-model-training.yml
+++ b/.github/workflows/lint-and-test-model-training.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint flake8
+        pip install pylint flake8 joblib scikit-learn pandas libml
 
     - name: Run pylint
       run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# model-training
+# model-training 7777
 
 **Overview**
 This repository contains the training pipeline for the Restaurant Sentiment Analysis model. It preprocesses data, trains the model, and stores the trained model in a versioned manner for use in the `model-service`. Once the model is trained, upload the model through GitHub Release. The personal contribution can be seen from `ACTIVITY.md`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# model-training 7777
+# model-training 
 
 **Overview**
 This repository contains the training pipeline for the Restaurant Sentiment Analysis model. It preprocesses data, trains the model, and stores the trained model in a versioned manner for use in the `model-service`. Once the model is trained, upload the model through GitHub Release. The personal contribution can be seen from `ACTIVITY.md`.

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,16 +1,15 @@
 stages:
   preprocess:
-    cmd: python sentiment_model_trainer/preprocess.py --input data/raw/a1_RestaurantReviews_HistoricDump.tsv
-      --output data/processed/preprocessed_data.pkl
+    cmd: python sentiment_model_trainer/preprocess.py --input data/raw/a1_RestaurantReviews_HistoricDump.tsv --output data/processed/preprocessed_data.pkl
     deps:
     - data/raw/a1_RestaurantReviews_HistoricDump.tsv
     - sentiment_model_trainer/preprocess.py
     outs:
     - data/processed/preprocessed_data.pkl
     - artifacts/c1_BoW_Sentiment_Model.pkl
+
   train:
-    cmd: python sentiment_model_trainer/train.py --input data/processed/preprocessed_data.pkl --vectorizer artifacts/c1_BoW_Sentiment_Model.pkl --model
-      models/sentiment-model.pkl --metrics artifacts/accuracy.json
+    cmd: python sentiment_model_trainer/train.py --input data/processed/preprocessed_data.pkl --vectorizer artifacts/c1_BoW_Sentiment_Model.pkl --model models/sentiment-model.pkl --metrics artifacts/accuracy.json
     deps:
     - data/processed/preprocessed_data.pkl
     - artifacts/c1_BoW_Sentiment_Model.pkl
@@ -20,15 +19,20 @@ stages:
     metrics:
     - artifacts/accuracy.json:
         cache: false
+    params:
+    - params.yaml
+
   evaluate:
-    cmd: python sentiment_model_trainer/evaluate.py --model models/sentiment-model-without-vectorizer.pkl --data data/processed/preprocessed_data.pkl
-      --output artifacts/evaluation.json
+    cmd: python sentiment_model_trainer/evaluate.py --model models/sentiment-model-without-vectorizer.pkl --data data/processed/preprocessed_data.pkl --output artifacts/evaluation.json
     deps:
     - data/processed/preprocessed_data.pkl
     - models/sentiment-model-without-vectorizer.pkl
     - sentiment_model_trainer/evaluate.py
     outs:
     - artifacts/evaluation.json
+    metrics:
+    - artifacts/evaluation.json
+
   test:
     cmd: ./run_all_test.bash
     deps:
@@ -36,4 +40,4 @@ stages:
     - tests/
     - requirements.txt
     metrics:
-      - metrics/test_metrics.json
+    - metrics/test_metrics.json

--- a/tests/test_feature_cost.py
+++ b/tests/test_feature_cost.py
@@ -1,0 +1,11 @@
+import time
+from tests.utils_test import return_model
+
+pipeline = return_model()
+
+def test_inference_time_large_input():
+    text = "very " * 1000 + "good"
+    start = time.time()
+    pipeline.predict([text])[0]
+    elapsed = time.time() - start
+    assert elapsed < 2.0

--- a/tests/test_feature_cost.py
+++ b/tests/test_feature_cost.py
@@ -1,7 +1,9 @@
 import time
 from tests.utils_test import return_model
 
+
 pipeline = return_model()
+
 
 def test_inference_time_large_input():
     text = "very " * 1000 + "good"

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,19 @@
+import requests
+import re
+
+def test_prometheus_metrics_format():
+    response = requests.get("http://localhost:8080/metrics")
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["Content-Type"]
+    assert "# HELP" in response.text
+
+def test_custom_metrics_present():
+    response = requests.get("http://localhost:8080/metrics")
+    content = response.text
+    expected_metrics = [
+        "webapp_predictions_total",
+        "webapp_response_latency_seconds",
+        "webapp_ram_usage_bytes"
+    ]
+    for metric in expected_metrics:
+        assert re.search(rf"^{metric}(\{{.*\}})?\s", content, re.MULTILINE)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,11 +1,13 @@
 import requests
 import re
 
+
 def test_prometheus_metrics_format():
     response = requests.get("http://localhost:8080/metrics")
     assert response.status_code == 200
     assert "text/plain" in response.headers["Content-Type"]
     assert "# HELP" in response.text
+
 
 def test_custom_metrics_present():
     response = requests.get("http://localhost:8080/metrics")


### PR DESCRIPTION
This PR adds black-box tests under tests/test_monitoring.py to verify Prometheus metrics exposure from the app-service running in Kubernetes. The tests check:

/metrics endpoint returns valid Prometheus format

Required metrics (webapp_predictions_total, webapp_response_latency_seconds, webapp_ram_usage_bytes) are present